### PR TITLE
Fix wrong discoveryApi call

### DIFF
--- a/.changeset/fifty-spoons-approve.md
+++ b/.changeset/fifty-spoons-approve.md
@@ -1,0 +1,5 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer-backend': patch
+---
+
+Fix discoveryApi call by getting the externalBaseUrl instead of the baseUrl

--- a/plugins/s3-viewer-backend/src/service/S3Api.ts
+++ b/plugins/s3-viewer-backend/src/service/S3Api.ts
@@ -184,7 +184,7 @@ export class S3Client implements S3Api {
     bucket: string,
     key: string,
   ): Promise<string> {
-    const s3Url = await this.discoveryApi.getBaseUrl('s3');
+    const s3Url = await this.discoveryApi.getExternalBaseUrl('s3');
     const url = new URL(
       `${s3Url}/stream/${encodeURIComponent(bucket)}/${encodeURIComponent(
         key,


### PR DESCRIPTION
Fixed the function to get the preview and download links. It was using the api call that returns the internal endpoint, but not the external one.