### PR TITLE
Minor improvements in TreePicker

### DIFF
--- a/.changeset/weak-planets-fly.md
+++ b/.changeset/weak-planets-fly.md
@@ -1,0 +1,5 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer': patch
+---
+
+Added `Tooltip` to the `S3BucketTreePicker` elements & fix of missing key to list elements

--- a/plugins/s3-viewer/src/components/S3BucketTreePicker/S3BucketTreePicker.tsx
+++ b/plugins/s3-viewer/src/components/S3BucketTreePicker/S3BucketTreePicker.tsx
@@ -9,6 +9,7 @@ import {
   ListItem,
   ListItemText,
   makeStyles,
+  Tooltip,
   Typography,
 } from '@material-ui/core';
 import { BackstageTheme } from '@backstage/theme';
@@ -91,11 +92,10 @@ export const S3BucketTreePicker = ({
     <List dense className={classes.list}>
       {Object.entries(bucketsByEndpoint).map(
         ([endpointName, buckets], idxOne) => (
-          <>
+          <React.Fragment key={idxOne}>
             <ListItem
               className={classes.endpoint}
               onClick={() => handleCollapseClick(endpointName)}
-              key={idxOne}
             >
               <ListItemText primary={endpointName} />
               {open === endpointName ? <ExpandLess /> : <ExpandMore />}
@@ -117,12 +117,14 @@ export const S3BucketTreePicker = ({
                       }
                     }}
                   >
-                    <ListItemText primary={bucketName} />
+                    <Tooltip title={bucketName}>
+                      <ListItemText primary={bucketName} />
+                    </Tooltip>
                   </ListItem>
                 ))}
               </List>
             </Collapse>
-          </>
+          </React.Fragment>
         ),
       )}
     </List>


### PR DESCRIPTION
While trying the permissions-setup, I noticed these small issues:

Basically, added a Fragment as a root for the first map iteration, this fixes an error shown in the developer console caused by having a list without a proper key element. If you wonder why I'm not using a simple `Box`, apparently that is not allowed, and the lint command was failing in such case, even though the UI looked exactly the same way as with the Fragment.

Also, added a Tooltip for the ListItems. If the screen is too small, the text might be cropped, making it hard to determine the actual bucket name, specially if several buckets have a similar name. In this way it makes it easier to the user to find the correct bucket.

This is not really important to update in our backstage instance right now, we could just do it within the next backstage upgrade.