### PR TITLE
Don't wait for `fetchBuckets` method on init

### DIFF
--- a/.changeset/brave-tips-trade.md
+++ b/.changeset/brave-tips-trade.md
@@ -1,0 +1,5 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer-backend': patch
+---
+
+Speed up backend startup by not waiting for the `S3BucketsProvider` to fetch all the buckets when the `S3Builder.build()` method is called. Let it do it asynchronously.

--- a/plugins/s3-viewer-backend/src/service/S3BucketsProvider.ts
+++ b/plugins/s3-viewer-backend/src/service/S3BucketsProvider.ts
@@ -26,13 +26,13 @@ export class S3BucketsProvider implements BucketsProvider {
     this.bucketCreds = [];
   }
 
-  static async create(
+  static create(
     logger: Logger,
     scheduler: PluginTaskScheduler,
     credentialsProvider: CredentialsProvider,
     statsProvider: BucketStatsProvider | undefined,
     refreshInterval: HumanDuration | undefined,
-  ): Promise<S3BucketsProvider> {
+  ): S3BucketsProvider {
     const bucketsProvider = new S3BucketsProvider(
       logger,
       scheduler,
@@ -40,7 +40,8 @@ export class S3BucketsProvider implements BucketsProvider {
       statsProvider,
       refreshInterval,
     );
-    await bucketsProvider.start();
+    // Don't wait for bucket fetch. This speeds up the backend startup process.
+    bucketsProvider.start();
 
     return bucketsProvider;
   }
@@ -58,6 +59,7 @@ export class S3BucketsProvider implements BucketsProvider {
   }
 
   async fetchBuckets(): Promise<void> {
+    this.logger.info('Fetching S3 buckets...');
     const bucketDetails: BucketDetails[] = [];
     const bucketCredentials =
       await this.credentialsProvider.getBucketCredentials();
@@ -125,6 +127,7 @@ export class S3BucketsProvider implements BucketsProvider {
 
     this.buckets = bucketDetails;
     this.bucketCreds = bucketCredentials;
+    this.logger.info(`Fetched ${this.buckets.length} S3 buckets`);
   }
 
   getAllBuckets(filter?: BucketDetailsFilters): string[] {

--- a/plugins/s3-viewer-backend/src/service/S3Builder.ts
+++ b/plugins/s3-viewer-backend/src/service/S3Builder.ts
@@ -84,17 +84,13 @@ export class S3Builder {
 
     this.bucketsProvider =
       this.bucketsProvider ??
-      (await S3BucketsProvider.create(
+      S3BucketsProvider.create(
         logger,
         scheduler,
         credentialsProvider,
         this.statsProvider,
         this.refreshInterval,
-      ));
-
-    this.env.logger.info(
-      `Found ${this.bucketsProvider.getAllBuckets().length} S3 buckets`,
-    );
+      );
 
     this.client =
       this.client ??


### PR DESCRIPTION
This is a really small change which is meant to speed up the initialization of the backend plugin.

Since the last changes done in our internal S3 setup, it seems that the connection is slower and this plugin now takes up to 2 or 3 minutes to fetch all the buckets and their information, causing the whole backstage backend to be blocked until this happens.

Basically, now it's not awaiting for the `start` function in the `S3BucketsProvider`, but let it do it asynchronously. From now on, when we start the app and the buckets are being loaded, the s3-viewer will just be empty, but no crashes will happen at all, so it's safe to make this change.

I think this is a good improvement to the plugin, because this situation could happen to other companies. This should be merged before the open-sourcing (unless this PR is discarded). So we release a nicer initial working plugin.