### PR TITLE
Support previewing more images detecting based on file extension

### DIFF
--- a/.changeset/curly-cobras-warn.md
+++ b/.changeset/curly-cobras-warn.md
@@ -1,0 +1,5 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer': minor
+---
+
+Enable preview for more objects by falling back to file extension

--- a/plugins/s3-viewer/src/components/S3ObjectViewer/S3ObjectViewer.tsx
+++ b/plugins/s3-viewer/src/components/S3ObjectViewer/S3ObjectViewer.tsx
@@ -58,7 +58,13 @@ export const S3Preview = ({ objectInfo }: S3PreviewProps) => {
         'image/x-icon',
         'image/jpg',
         'image/png',
-      ].includes(obj.contentType)
+      ].includes(obj.contentType) &&
+      // fall back to detecting based on file name if type is unknown
+      !(
+        ['', 'binary/octet-stream', 'application/octet-stream'].includes(
+          obj.contentType,
+        ) && obj.name.match(/\.(gif|ico|jpg|jpeg|png|svg|tiff)$/)
+      )
     ) {
       return false;
     }


### PR DESCRIPTION
This still supports the same image types, but extends it for a lot more objects, at least with our internal buckets.

Tested with our internal buckets, works for many more images now.