### PR TITLE
Pin ceph container to latest stable vX version

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ceph:
-    image: quay.io/ceph/daemon:latest-pacific
+    image: quay.io/ceph/daemon:v7.0.1-stable-7.0-quincy-centos-stream8
     environment:
       - RGW_FRONTEND_TYPE=beast
       - RGW_FRONTEND_PORT=8080


### PR DESCRIPTION
Tested it and everything worked successfully again.

No huge memory usage of anything else. My laptop was all the time between 32% and 40% during the setup.

This is the latest version found with this command:

```shell
for i in {1..20}; do     
  curl -s -L https://quay.io/api/v1/repository/ceph/daemon/tag?page_size=100\&page=$i | jq '."tags"[] .name';
done | awk '/stable/'
```