### PR TITLE
Update README.md with missing "await"

### DIFF
--- a/plugins/s3-viewer-backend/README.md
+++ b/plugins/s3-viewer-backend/README.md
@@ -31,7 +31,7 @@ To get started, follow these steps:
     export default async function createPlugin(
       env: PluginEnvironment,
     ): Promise<Router> {
-      const { router } = S3Builder.createBuilder({
+      const { router } = await S3Builder.createBuilder({
         config: env.config,
         logger: env.logger,
         scheduler: env.scheduler,


### PR DESCRIPTION
I was only able to get the plugin to work by adding an "await" in the install instructions for backend/src/plugins/s3.ts

Please reject if I am simply not understanding something.