### PR TITLE
Allow the S3Builder to inject the used bucketsProvider into custom S3 clients

### DIFF
--- a/.changeset/odd-fans-wonder.md
+++ b/.changeset/odd-fans-wonder.md
@@ -1,0 +1,7 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer-backend': minor
+---
+
+Extend the `S3Api` interface to allow injecting the `bucketsProvider` with the method `setBucketsProvider`. This is optional, and allows the `S3Builder` to inject the used `bucketsProvider` into your custom client, without needing to use a custom one or having to duplicate the default one.
+
+This isn't breaking anything, since the new method is optional.

--- a/plugins/s3-viewer-backend/README.md
+++ b/plugins/s3-viewer-backend/README.md
@@ -187,6 +187,8 @@ First of all, the client used to communicate with the S3 buckets can be overwrit
   const { router } = await builder.build();
 ```
 
+In some cases you might need to use the internal `bucketsProvider` to fetch information for a bucket before making any request. In order to do that, the `S3Api` interface comes with an optional method `setBucketsProvider`. If defined in your client, the `build()` method will inject the `bucketsProvider` for you.
+
 ### Buckets Provider
 
 It is responsible for fetching all the bucket information for the obtained platforms and credentials, which were fetched by the `CredentialsProvider`. This interface is used in the router, so the data can be properly displayed later in the UI. This must implement the interface `BucketsProvider`. Use the method `setBucketsProvider` to override it:

--- a/plugins/s3-viewer-backend/src/service/S3Api.ts
+++ b/plugins/s3-viewer-backend/src/service/S3Api.ts
@@ -17,6 +17,12 @@ export interface S3ClientEnvironment {
 
 export interface S3Api {
   /**
+   * Sets the bucketsProvider, which might be needed to fetch credentials. This method
+   * is optional. Use it only if required.
+   * @param bucketsProvider The buckets provider used to get credentials for buckets
+   */
+  setBucketsProvider?(bucketsProvider: BucketsProvider): void;
+  /**
    * List the keys for a bucket.
    * @param endpoint The endpoint where the bucket is
    * @param bucket The bucket name

--- a/plugins/s3-viewer-backend/src/service/S3Builder.ts
+++ b/plugins/s3-viewer-backend/src/service/S3Builder.ts
@@ -99,6 +99,10 @@ export class S3Builder {
         discoveryApi: discovery,
       });
 
+    if (this.client.setBucketsProvider) {
+      this.client.setBucketsProvider(this.bucketsProvider);
+    }
+
     const router = this.buildRouter(this.client);
 
     return {


### PR DESCRIPTION
This tried to improve things found in #52 .

This is extending the current `S3Api` with a new optional method called `setBucketsProvider`. If defined in your custom S3 client, then the `S3Builder` will inject the used `bucketsProvider` into your client automatically.

As an example, this is how it would look:

```ts
export class S3CustomClient implements S3Api {
  private discoveryApi: DiscoveryService;
  private bucketsProvider?: BucketsProvider;

  constructor({ discoveryApi }: { discoveryApi: DiscoveryService }) {
    this.discoveryApi = discoveryApi;
  }

  setBucketsProvider(bucketsProvider: BucketsProvider): void {
    this.bucketsProvider = bucketsProvider;
  }

  private getS3Client(endpoint: string, bucket: string): S3 {
    if (!this.bucketsProvider) {
      throw new Error('bucketsProvider not set');
    }
    const data = this.bucketsProvider.getCredentialsForBucket(endpoint, bucket);
    if (!data) {
      throw new Error(`No credentials stored for ${endpoint}/${bucket}`);
    }

    const s3Client = new S3({
      apiVersion: '2006-03-01',
      credentials: {
        accessKeyId: data.credentials.accessKeyId,
        secretAccessKey: data.credentials.secretAccessKey,
      },
      endpoint: data.endpoint,
      region: data.region,
      forcePathStyle: true,
    });

    return s3Client;
  }

  async listBucketKeys(
    endpoint: string,
    bucket: string,
    continuationToken: string,
    pageSize: number,
    folder: string,
    prefix: string,
  ): Promise<ListBucketKeysResult> {
    const s3Client = this.getS3Client(endpoint, bucket);
    if (!this.bucketsProvider) {
      throw new Error('bucketsProvider not set');
    }
    const bucketInfo = this.bucketsProvider.getBucketInfo(endpoint, bucket);
    // ...code
  }

  async headObject(
    endpoint: string,
    bucket: string,
    key: string,
  ): Promise<FetchObjectResult> {
    // ...code
  }

  async streamObject(
    endpoint: string,
    bucket: string,
    key: string,
  ): Promise<Readable> {
    // ...code
  }
}

const { router } = await S3Builder.createBuilder({
    config,
    logger,
    scheduler,
    discovery,
    identity,
    permissions,
    tokenManager,
  })
    .setClient(new S3CustomClient({ discoveryApi: discovery }))
    .build();
```