### PR TITLE
Add missing exports for custom BucketsProvider

### DIFF
--- a/.changeset/lazy-gifts-compete.md
+++ b/.changeset/lazy-gifts-compete.md
@@ -1,0 +1,7 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer-backend': patch
+---
+
+Export function `matches` and type `BucketDetailsFilters` from the permissions folder.
+
+These 2 elements are needed to create a custom `BucketsProvider`.

--- a/plugins/s3-viewer-backend/src/index.ts
+++ b/plugins/s3-viewer-backend/src/index.ts
@@ -20,4 +20,6 @@ export * from './middleware';
 export {
   createS3ViewerBucketsConditionalDecision,
   s3ViewerBucketConditions,
+  matches,
 } from './permissions';
+export type { BucketDetailsFilters } from './permissions';


### PR DESCRIPTION
These 2 elements were required to create a custom BucketsProvider, so let's export them as well.

PS: Sorry for all the tiny MRs, but I preferred to do each thing in a different MR than all together :)