### PR TITLE
Fix package metadata

### DIFF
--- a/.changeset/polite-boats-jam.md
+++ b/.changeset/polite-boats-jam.md
@@ -1,0 +1,8 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer': patch
+'@spreadshirt/backstage-plugin-s3-viewer-backend': patch
+'@spreadshirt/backstage-plugin-s3-viewer-common': patch
+'@spreadshirt/backstage-plugin-s3-viewer-node': patch
+---
+
+Fix backstage package metadata

--- a/plugins/s3-viewer-backend/package.json
+++ b/plugins/s3-viewer-backend/package.json
@@ -15,10 +15,17 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/spreadshirt/backstage-plugin-s3",
-    "directory": "plugins/backstage-plugin-s3-viewer-backend"
+    "directory": "plugins/s3-viewer-backend"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "s3-viewer",
+    "pluginPackages": [
+      "@spreadshirt/backstage-plugin-s3-viewer",
+      "@spreadshirt/backstage-plugin-s3-viewer-backend",
+      "@spreadshirt/backstage-plugin-s3-viewer-common",
+      "@spreadshirt/backstage-plugin-s3-viewer-node"
+    ]
   },
   "scripts": {
     "start": "LEGACY_BACKEND_START=1 backstage-cli package start",

--- a/plugins/s3-viewer-common/package.json
+++ b/plugins/s3-viewer-common/package.json
@@ -17,10 +17,17 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/spreadshirt/backstage-plugin-s3",
-    "directory": "plugins/backstage-plugin-s3-viewer-common"
+    "directory": "plugins/s3-viewer-common"
   },
   "backstage": {
-    "role": "common-library"
+    "role": "common-library",
+    "pluginId": "s3-viewer",
+    "pluginPackages": [
+      "@spreadshirt/backstage-plugin-s3-viewer",
+      "@spreadshirt/backstage-plugin-s3-viewer-backend",
+      "@spreadshirt/backstage-plugin-s3-viewer-common",
+      "@spreadshirt/backstage-plugin-s3-viewer-node"
+    ]
   },
   "sideEffects": false,
   "scripts": {

--- a/plugins/s3-viewer-node/package.json
+++ b/plugins/s3-viewer-node/package.json
@@ -19,7 +19,14 @@
     "directory": "plugins/s3-viewer-node"
   },
   "backstage": {
-    "role": "node-library"
+    "role": "node-library",
+    "pluginId": "s3-viewer",
+    "pluginPackages": [
+      "@spreadshirt/backstage-plugin-s3-viewer",
+      "@spreadshirt/backstage-plugin-s3-viewer-backend",
+      "@spreadshirt/backstage-plugin-s3-viewer-common",
+      "@spreadshirt/backstage-plugin-s3-viewer-node"
+    ]
   },
   "scripts": {
     "build": "backstage-cli package build",

--- a/plugins/s3-viewer/package.json
+++ b/plugins/s3-viewer/package.json
@@ -15,10 +15,17 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/spreadshirt/backstage-plugin-s3",
-    "directory": "plugins/backstage-plugin-s3-viewer"
+    "directory": "plugins/s3-viewer"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "s3-viewer",
+    "pluginPackages": [
+      "@spreadshirt/backstage-plugin-s3-viewer",
+      "@spreadshirt/backstage-plugin-s3-viewer-backend",
+      "@spreadshirt/backstage-plugin-s3-viewer-common",
+      "@spreadshirt/backstage-plugin-s3-viewer-node"
+    ]
   },
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
During the publish process, the pipeline failed because of a recent change in the way the packages are published. In concrete, with the command "yarn backstage-cli package prepack".

This also happened to changes done upstream like the vault and grafana plugins. It's something recent and seems like they are being fixed on the fly when they occur.

Just if you're curious, these are the MRs I refer to:

https://github.com/backstage/community-plugins/pull/613
https://github.com/backstage/community-plugins/pull/614