### PR TITLE
Fix publish and ci pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,22 @@ jobs:
   build:
     name: Run Unit Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
-      - name: Install Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
         with:
-          node-version: 20.x
-      - run: yarn install
-      - run: yarn ci
-        env:
-          CI: true
-      - run: yarn dedupe
+          fetch-depth: '0'
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn install --immutable
+      - run: yarn lint
+      - run: yarn prettier:check
+      - run: yarn fix --check
+      - run: yarn tsc
+      - run: yarn build:all
+      - run: yarn test:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20.x
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn install --immutable
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:all": "backstage-cli repo test --coverage",
     "fix": "backstage-cli repo fix --publish",
     "lint": "backstage-cli repo lint",
-    "ci": "yarn install && tsc && yarn build:all && backstage-cli test --no-watch && yarn lint",
+    "ci": "yarn install --immutable && tsc && yarn build:all && backstage-cli test --no-watch && yarn lint",
     "start:frontend": "yarn workspace @spreadshirt/backstage-plugin-s3-viewer start",
     "start:backend": "yarn workspace @spreadshirt/backstage-plugin-s3-viewer-backend start",
     "start": "concurrently \"yarn start:backend\" \"yarn start:frontend\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6716,8 +6716,8 @@ __metadata:
     "@backstage/types": "npm:^1.1.1"
     "@smithy/protocol-http": "npm:^4.1.0"
     "@smithy/signature-v4": "npm:^4.1.0"
-    "@spreadshirt/backstage-plugin-s3-viewer-common": "npm:^0.5.6"
-    "@spreadshirt/backstage-plugin-s3-viewer-node": "npm:0.2.6"
+    "@spreadshirt/backstage-plugin-s3-viewer-common": "npm:^0.5.7"
+    "@spreadshirt/backstage-plugin-s3-viewer-node": "npm:0.2.7"
     "@types/cookie-parser": "npm:^1.4.3"
     "@types/express": "npm:*"
     "@types/jest": "npm:*"
@@ -6736,7 +6736,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spreadshirt/backstage-plugin-s3-viewer-common@npm:^0.5.6, @spreadshirt/backstage-plugin-s3-viewer-common@workspace:plugins/s3-viewer-common":
+"@spreadshirt/backstage-plugin-s3-viewer-common@npm:^0.5.7, @spreadshirt/backstage-plugin-s3-viewer-common@workspace:plugins/s3-viewer-common":
   version: 0.0.0-use.local
   resolution: "@spreadshirt/backstage-plugin-s3-viewer-common@workspace:plugins/s3-viewer-common"
   dependencies:
@@ -6746,13 +6746,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spreadshirt/backstage-plugin-s3-viewer-node@npm:0.2.6, @spreadshirt/backstage-plugin-s3-viewer-node@workspace:plugins/s3-viewer-node":
+"@spreadshirt/backstage-plugin-s3-viewer-node@npm:0.2.7, @spreadshirt/backstage-plugin-s3-viewer-node@workspace:plugins/s3-viewer-node":
   version: 0.0.0-use.local
   resolution: "@spreadshirt/backstage-plugin-s3-viewer-node@workspace:plugins/s3-viewer-node"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.0.0"
     "@backstage/cli": "npm:^0.27.1"
-    "@spreadshirt/backstage-plugin-s3-viewer-common": "npm:^0.5.6"
+    "@spreadshirt/backstage-plugin-s3-viewer-common": "npm:^0.5.7"
     "@types/express": "npm:*"
     express: "npm:^4.17.1"
     stream: "npm:^0.0.2"
@@ -6772,7 +6772,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
-    "@spreadshirt/backstage-plugin-s3-viewer-common": "npm:^0.5.6"
+    "@spreadshirt/backstage-plugin-s3-viewer-common": "npm:^0.5.7"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
     "@testing-library/user-event": "npm:^14.0.0"


### PR DESCRIPTION
This should be fixing the CI pipelines. For some reason they were working well in the pull requests, but not in main.

Seems like the publish step have never updated the `yarn.lock`.

The last release (with yarn4): https://github.com/spreadshirt/backstage-plugin-s3/pull/127/files
The previous release (with yarn1): https://github.com/spreadshirt/backstage-plugin-s3/pull/123/files

Since yarn3, if a change will happen, it will crash completely in the CI, which is a nice feature, but we never found out.

Might be that the changeset commands we use are not really supporting this. 

As an alternative, and inspiration, check other projects like this: https://github.com/drodil/backstage-plugin-toolbox