### PR TITLE
Don't unconditionally add `download` property to "Download" anchor tags.

### DIFF
--- a/.changeset/tough-trees-taste.md
+++ b/.changeset/tough-trees-taste.md
@@ -1,0 +1,5 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer': patch
+---
+
+Don't unconditionally add "download" property to "Download" links

--- a/plugins/s3-viewer/src/components/S3ObjectViewer/S3ObjectViewer.tsx
+++ b/plugins/s3-viewer/src/components/S3ObjectViewer/S3ObjectViewer.tsx
@@ -158,7 +158,6 @@ export const S3ObjectViewer = ({
               variant="outlined"
               title={`Download ${objectInfo.downloadName}`}
               to={objectInfo.downloadUrl}
-              download={objectInfo.downloadName}
             >
               Download
             </LinkButton>


### PR DESCRIPTION
Adding the `download` property defeats the changes in #158.

Instead rely on the presence of the "Content-Disposition: attachment" header for whether or not the browser will download or open the linked file.

This allows viewing html files as web pages in the browser rather than having the browser download them attachments, which is the experience that users prefer for html by default.