### PR TITLE
Fix logic in the HTML content type check.

### DIFF
--- a/.changeset/calm-lions-crash.md
+++ b/.changeset/calm-lions-crash.md
@@ -1,0 +1,5 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer-backend': patch
+---
+
+Fix logic in HTML content type check. It was previously reversed

--- a/plugins/s3-viewer-backend/src/service/S3Builder.ts
+++ b/plugins/s3-viewer-backend/src/service/S3Builder.ts
@@ -407,7 +407,7 @@ export class S3Builder {
       const object = await client.headObject(endpoint as string, bucket, key);
       res.setHeader('Access-Control-Expose-Headers', 'Content-Disposition');
       // Enable viewing html as web pages, while downloading other file types.
-      if (object.contentType.trim().startsWith('text/html')) {
+      if (!object.contentType.trim().startsWith('text/html')) {
         res.setHeader(
           'Content-Disposition',
           `attachment; filename="${object.downloadName}"`,


### PR DESCRIPTION
As a follow up to https://github.com/spreadshirt/backstage-plugin-s3/pull/158 I tested in our Backstage instance and found that the text/html check was negated.