### PR TITLE
Fix s3-viewer frontend plugin exports (CJS vs ESM)

### DIFF
--- a/.changeset/public-rivers-see.md
+++ b/.changeset/public-rivers-see.md
@@ -1,0 +1,8 @@
+---
+'@spreadshirt/backstage-plugin-s3-viewer': patch
+---
+
+Fix broken exports after Backstage 1.54.x update
+
+The imports didn't work because they were written for CJS, which doesn't seem to
+be exported for frontend plugins.

--- a/plugins/s3-viewer/package.json
+++ b/plugins/s3-viewer/package.json
@@ -8,24 +8,14 @@
     "access": "public",
     "exports": {
       ".": {
-        "import": {
-          "types": "./dist/index.d.ts",
-          "default": "./dist/index.esm.js"
-        },
-        "require": {
-          "types": "./dist/index.d.ts",
-          "default": "./dist/index.cjs.js"
-        }
+        "import": "./dist/index.esm.js",
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.esm.js"
       },
       "./alpha": {
-        "import": {
-          "types": "./dist/alpha.d.ts",
-          "default": "./dist/alpha.esm.js"
-        },
-        "require": {
-          "types": "./dist/alpha.d.ts",
-          "default": "./dist/alpha.cjs.js"
-        }
+        "import": "./dist/alpha.esm.js",
+        "types": "./dist/alpha.d.ts",
+        "default": "./dist/alpha.esm.js"
       },
       "./package.json": "./package.json"
     }


### PR DESCRIPTION
Fixes export issues created in #240.

Importing the package failed with the following:

```
× Module not found: Can't resolve '@spreadshirt/backstage-plugin-s3-viewer' in '/home/<redacted>/projects/backstage/packages/app/node_modules'
```